### PR TITLE
refactor: remove unused CurrentUser decorator and simplify JwtAuthGuard

### DIFF
--- a/src/domain/auth/jwt-auth.guard.ts
+++ b/src/domain/auth/jwt-auth.guard.ts
@@ -1,10 +1,3 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
-import { UserPayload } from './jwt.strategy';
+import { AuthGuard } from '@nestjs/passport';
 
-export const CurrentUser = createParamDecorator(
-  (_: never, context: ExecutionContext) => {
-    const request = context.switchToHttp().getRequest();
-
-    return request.user as UserPayload;
-  },
-);
+export class JwtAuthGuard extends AuthGuard('jwt') {}


### PR DESCRIPTION
This pull request includes changes to the `src/domain/auth/jwt-auth.guard.ts` file to enhance the authentication mechanism by utilizing the `AuthGuard` from `@nestjs/passport` instead of a custom decorator. The most important changes are:

Enhancements to authentication mechanism:

* [`src/domain/auth/jwt-auth.guard.ts`](diffhunk://#diff-a3a6e9e3cf9232339547b6bd9c43be70722e4a532b41aa66e1a92f3c7390ad0aL1-R3): Replaced the custom `CurrentUser` decorator with a new `JwtAuthGuard` class that extends `AuthGuard('jwt')` from `@nestjs/passport`. This change simplifies the authentication process by leveraging built-in functionality from the NestJS Passport module.