### PR TITLE
add artisan creation request table

### DIFF
--- a/prisma/migrations/20250422232758_create_artisan_creation_request_table/migration.sql
+++ b/prisma/migrations/20250422232758_create_artisan_creation_request_table/migration.sql
@@ -1,0 +1,34 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `is_disable` on the `artisans_profile` table. All the data in the column will be lost.
+  - You are about to drop the column `pending_request` on the `artisans_profile` table. All the data in the column will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "RequestStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "artisans_profile" DROP COLUMN "is_disable",
+DROP COLUMN "pending_request",
+ADD COLUMN     "is_disabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "artisan_creation_requests" (
+    "id" TEXT NOT NULL,
+    "fk_user_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "status" "RequestStatus" NOT NULL DEFAULT 'PENDING',
+    "fk_user_reviewer_id" TEXT,
+    "reviwed_at" TIMESTAMP(3),
+    "reason" TEXT,
+
+    CONSTRAINT "artisan_creation_requests_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "artisan_creation_requests" ADD CONSTRAINT "artisan_creation_requests_fk_user_id_fkey" FOREIGN KEY ("fk_user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "artisan_creation_requests" ADD CONSTRAINT "artisan_creation_requests_fk_user_reviewer_id_fkey" FOREIGN KEY ("fk_user_reviewer_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
 }
 
 enum Role {
@@ -13,6 +12,12 @@ enum Role {
   ARTISAN
   MODERATOR
   ADMIN
+}
+
+enum RequestStatus {
+  PENDING
+  APPROVED
+  REJECTED
 }
 
 model User {
@@ -24,9 +29,11 @@ model User {
   createdAt  DateTime @default(now()) @map("created_at")
   updatedAt  DateTime @updatedAt @map("updated_at")
 
-  profile  UserProfile?
-  artisan  ArtisanProfile?
-  sessions Session[]
+  profile                         UserProfile?
+  artisan                         ArtisanProfile?
+  sessions                        Session[]
+  artisanCreationRequestsSent     ArtisanCreationRequest[] @relation("userRequesting")
+  artisanCreationRequestsReviewed ArtisanCreationRequest[] @relation("userReviewer")
 
   @@map("users")
 }
@@ -59,12 +66,27 @@ model ArtisanProfile {
   sicab                  String
   sisabRegistrationDate  DateTime @map("sisab_registration_date")
   sisabValidUntil        DateTime @map("sisab_valid_until")
-  pendingRequest         Boolean  @default(false) @map("pending_request")
-  isDisabled             Boolean  @default(false) @map("is_disable")
+  isDisabled             Boolean  @default(false) @map("is_disabled")
 
   user User @relation(fields: [userId], references: [id])
 
   @@map("artisans_profile")
+}
+
+model ArtisanCreationRequest {
+  id         String        @id @default(uuid())
+  userId     String        @map("fk_user_id")
+  createdAt  DateTime      @default(now()) @map("created_at")
+  updatedAt  DateTime      @default(now()) @map("updated_at")
+  status     RequestStatus @default(PENDING)
+  reviewerId String?       @map("fk_user_reviewer_id")
+  reviwedAt  DateTime?     @map("reviwed_at")
+  reason     String?
+
+  userRequesting User  @relation(fields: [userId], references: [id], name: "userRequesting")
+  userReviwer    User? @relation(fields: [reviewerId], references: [id], name: "userReviewer")
+
+  @@map("artisan_creation_requests")
 }
 
 model Session {


### PR DESCRIPTION
This pull request introduces significant changes to the database schema and Prisma models to support a new feature for managing artisan creation requests. The changes include creating a new table and enum, modifying existing models, and removing deprecated fields.

### Database Schema Changes:

* Created a new `RequestStatus` enum with values `PENDING`, `APPROVED`, and `REJECTED` to represent the status of artisan creation requests. (`[[1]](diffhunk://#diff-932c0e0cff147ad027e95e8c3c25e6cd864fc0d389041050f47e8968afdd5742R1-R34)`, `[[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR17-R22)`)
* Added a new `artisan_creation_requests` table with fields for tracking request details, including status, reviewer, timestamps, and reason. Foreign key relationships were established with the `users` table for both the requesting user and the reviewer. (`[prisma/migrations/20250422232758_create_artisan_creation_request_table/migration.sqlR1-R34](diffhunk://#diff-932c0e0cff147ad027e95e8c3c25e6cd864fc0d389041050f47e8968afdd5742R1-R34)`)
* Removed the `is_disable` and `pending_request` columns from the `artisans_profile` table, replacing them with a single `is_disabled` column. (`[prisma/migrations/20250422232758_create_artisan_creation_request_table/migration.sqlR1-R34](diffhunk://#diff-932c0e0cff147ad027e95e8c3c25e6cd864fc0d389041050f47e8968afdd5742R1-R34)`)

### Prisma Model Changes:

* Added the `RequestStatus` enum to the Prisma schema. (`[prisma/schema.prismaR17-R22](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR17-R22)`)
* Created a new `ArtisanCreationRequest` model to represent artisan creation requests, including relationships with the `User` model for both the requesting user and the reviewer. (`[prisma/schema.prismaL62-R91](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL62-R91)`)
* Updated the `User` model to include relations for the requests sent and reviewed (`artisanCreationRequestsSent` and `artisanCreationRequestsReviewed`). (`[prisma/schema.prismaR35-R36](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cR35-R36)`)
* Updated the `ArtisanProfile` model to replace the deprecated `pendingRequest` and `isDisabled` fields with the new `isDisabled` field mapped to the updated column. (`[prisma/schema.prismaL62-R91](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL62-R91)`)

### Minor Changes:

* Removed the `directUrl` property from the `datasource db` block in the Prisma schema. (`[prisma/schema.prismaL8](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL8)`)…schema

closes #36 