### PR TITLE
feat: include email in GetAllArtisanApplicationsWithUserNamesOutput

### DIFF
--- a/src/domain/identity/core/use-cases/get-all-artisan-applications-with-user-names.use-case.ts
+++ b/src/domain/identity/core/use-cases/get-all-artisan-applications-with-user-names.use-case.ts
@@ -8,6 +8,7 @@ import { PrismaUsersRepository } from '../../persistence/prisma/repositories/pri
 export interface GetAllArtisanApplicationsWithUserNamesOutput {
   id: string;
   artisanName: string;
+  email: string;
   rawMaterial: string;
   technique: string;
   sicab: string;
@@ -43,6 +44,7 @@ export class GetAllArtisanApplicationsWithUserNamesUseCase {
       return {
         id: ap.id,
         artisanName: user?.name,
+        email: user?.email,
         rawMaterial: ap.rawMaterial,
         technique: ap.technique,
         sicab: ap.sicab,


### PR DESCRIPTION
This pull request introduces a small enhancement to the `GetAllArtisanApplicationsWithUserNamesUseCase` by including the user's email in the output. This change ensures that the email field is now part of the returned data structure.

* [`src/domain/identity/core/use-cases/get-all-artisan-applications-with-user-names.use-case.ts`](diffhunk://#diff-da9ef71ec4bb7304c222d66489e6e34e97cb215347a3197b1057ae951dcfd142R11): Added the `email` field to the `GetAllArtisanApplicationsWithUserNamesOutput` interface and included `user?.email` in the mapped output. [[1]](diffhunk://#diff-da9ef71ec4bb7304c222d66489e6e34e97cb215347a3197b1057ae951dcfd142R11) [[2]](diffhunk://#diff-da9ef71ec4bb7304c222d66489e6e34e97cb215347a3197b1057ae951dcfd142R47)