### PR TITLE
feat: update environment configuration for PostgreSQL and MinIO services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,38 @@
-# Environment
-PORT=3333
+## PostgreSQL
+POSTGRES_CONTAINER_NAME="YOUR-CONTAINER-NAME"     # Name of the PostgreSQL container in Docker
+POSTGRES_PORT=5432                                # PostgreSQL port (default: 5432)
+POSTGRES_USER="YOUR-POSTGRES-USER-NAME"           # PostgreSQL username
+POSTGRES_PASSWORD="YOUR-POSTGRES-PASSWORD"        # PostgreSQL password
+POSTGRES_DB_NAME="YOUR-POSTGRES-DB-NAME"          # PostgreSQL database name
+POSTGRES_HOSTNAME="YOUR-POSTGRES-HOSTNAME"        # PostgreSQL hostname (e.g., 'localhost')
 
-# Prisma
-DATABASE_URL="postgresql://[USERNAME]:[PASSWORD]@[HOST]:5432/[DATABASE]?schema=public"
+## MinIO (S3 compatible storage)
+MINIO_CONTAINER_NAME="YOUR-CONTAINER-NAME"        # Name of the MinIO container in Docker
+MINIO_PORT_API=9000                               # MinIO API port (default: 9000)
+MINIO_PORT_CONSOLE=9001                           # MinIO Web Console port (default: 9001)
+MINIO_ROOT_USER="YOUR-MINIO-ROOT-USER"            # MinIO root username
+MINIO_ROOT_PASSWORD="YOUR-MINIO-ROOT-PASSWORD"    # MinIO root password
+MINIO_BUCKET_NAME="YOUR-BUCKET-NAME"              # Default MinIO bucket name
+MINIO_HOST_URL="[HTTP(S)]://YOUR-MINIO-HOST"      # MinIO host URL (e.g., http://localhost)
 
-# JWT
-JWT_PRIVATE_KEY="[PRIVATE_BASE64]"
-JWT_PUBLIC_KEY="[PUBLIC_BASE64]"
+# Application Configuration
 
-# STORAGE S3 API
-STORAGE_URL="[YOUR_STORAGE_URL]"
-STORAGE_BUCKET_NAME="[YOUR_STORAGE_BUCKET_NAME]"
-STORAGE_ACCESS_KEY_ID="[YOUR_STORAGE_ACCESS_KEY_ID]"
-STORAGE_SECRET_ACCESS_KEY="[YOUR_STORAGE_SECRET_ACCESS_KEY]"
+PORT=3333                                         # Application port (NestJS)
+
+# Prisma (Database)
+
+# Connection URL for Prisma to PostgreSQL
+DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOSTNAME}:${POSTGRES_PORT}/${POSTGRES_DB_NAME}?schema=public"
+
+# JWT (Authentication)
+
+# Base64 keys for signing and verifying JWT tokens
+JWT_PRIVATE_KEY="YOUR-PRIVATE-KEY-BASE64"         # Private key for JWT signing
+JWT_PUBLIC_KEY="YOUR-PUBLIC-KEY-BASE64"           # Public key for JWT verification
+
+# Storage S3 API (MinIO or AWS S3)
+
+STORAGE_URL="${MINIO_HOST_URL}:${MINIO_PORT_API}"     # S3 endpoint URL
+STORAGE_BUCKET_NAME="${MINIO_BUCKET_NAME}"            # S3 bucket name for file storage
+STORAGE_ACCESS_KEY_ID="${MINIO_ROOT_USER}"            # S3 access key
+STORAGE_SECRET_ACCESS_KEY="${MINIO_ROOT_PASSWORD}"    # S3 secret key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,27 +2,39 @@ version: '3.9'
 
 services:
   postgres: 
-    container_name: postgres
+    container_name: ${POSTGRES_CONTAINER_NAME}
     image: postgres
     ports:
-      - 5432:5432
+      - "${POSTGRES_PORT}:5432"
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: postgres
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
 
   minio:
     image: minio/minio
-    container_name: minio
+    container_name: ${MINIO_CONTAINER_NAME}
     ports:
-      - "9000:9000"     # S3 API
-      - "9001:9001"     # Painel web
+      - "${MINIO_PORT_API}:9000"     # S3 API
+      - "${MINIO_PORT_CONSOLE}:9001" # Painel web
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      MINIO_BUCKET_NAME: ${MINIO_BUCKET_NAME}
     command: server /data --console-address ":9001"
     volumes:
       - minio-data:/data
+
+  mc:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5 &&
+      mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD} &&
+      mc mb myminio/${MINIO_BUCKET_NAME} --ignore-existing
+      "
 
 volumes:
   minio-data:


### PR DESCRIPTION
This pull request updates the environment configuration and Docker Compose setup to make the application more flexible and easier to configure via environment variables. The changes focus on improving the management of PostgreSQL and MinIO (S3-compatible storage) services, and on streamlining the initialization of these services for local development.

**Environment variable improvements:**

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL1-R38): Reorganized and expanded environment variables for PostgreSQL and MinIO, providing clear documentation and default values to simplify local setup and configuration. Variables are now grouped by service, and references to these variables are used throughout the configuration.

**Docker Compose enhancements:**

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L5-R38): Updated to use the new environment variables for container names, ports, and credentials for both PostgreSQL and MinIO, making the setup more flexible and consistent with the `.env.example` file.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L5-R38): Added a new `mc` (MinIO Client) service to automatically create the specified MinIO bucket at startup, improving the developer experience and reducing manual setup steps.