### PR TITLE
Get product by id/#67

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ POSTGRES_CONTAINER_NAME="YOUR-CONTAINER-NAME"     # Name of the PostgreSQL conta
 POSTGRES_PORT=5432                                # PostgreSQL port (default: 5432)
 POSTGRES_USER="YOUR-POSTGRES-USER-NAME"           # PostgreSQL username
 POSTGRES_PASSWORD="YOUR-POSTGRES-PASSWORD"        # PostgreSQL password
-POSTGRES_DB_NAME="YOUR-POSTGRES-DB-NAME"          # PostgreSQL database name
+POSTGRES_DB="YOUR-POSTGRES-DB-NAME"          # PostgreSQL database name
 POSTGRES_HOSTNAME="YOUR-POSTGRES-HOSTNAME"        # PostgreSQL hostname (e.g., 'localhost')
 
 ## MinIO (S3 compatible storage)
@@ -13,7 +13,7 @@ MINIO_PORT_CONSOLE=9001                           # MinIO Web Console port (defa
 MINIO_ROOT_USER="YOUR-MINIO-ROOT-USER"            # MinIO root username
 MINIO_ROOT_PASSWORD="YOUR-MINIO-ROOT-PASSWORD"    # MinIO root password
 MINIO_BUCKET_NAME="YOUR-BUCKET-NAME"              # Default MinIO bucket name
-MINIO_HOST_URL="[HTTP(S)]://YOUR-MINIO-HOST"      # MinIO host URL (e.g., http://localhost)
+MINIO_HOST_URL="HTTP(S)://YOUR-MINIO-HOST"      # MinIO host URL (e.g., http://localhost)
 
 # Application Configuration
 

--- a/src/domain/_shared/attachments/core/use-cases/upload-attachment.use-case.ts
+++ b/src/domain/_shared/attachments/core/use-cases/upload-attachment.use-case.ts
@@ -33,15 +33,16 @@ export class UploadAttachmentUseCase {
       return left(new InvalidAttachmentTypeError(fileType));
     }
 
-    const { id } = await this.s3Storage.upload({
-      fileType,
-      body,
-    });
-
     const attachment = Attachment.create({
       mimeType: fileType,
       sizeInBytes: fileSize,
-    }, id);
+    });
+
+    await this.s3Storage.upload({
+      fileType,
+      body,
+      fileName: attachment.id,
+    });
 
     await this.prismaAttachmentsRepository.save(attachment);
 

--- a/src/domain/_shared/attachments/persistence/storage/s3-attachments.storage.ts
+++ b/src/domain/_shared/attachments/persistence/storage/s3-attachments.storage.ts
@@ -1,11 +1,11 @@
 import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Injectable } from '@nestjs/common';
-import { randomUUID } from 'node:crypto';
 import { ConfigService } from '@nestjs/config';
 import { Env } from '@/shared/env/env';
 
 export interface UploadParams {
+  fileName: string;
   fileType: string;
   body: Buffer;
 }
@@ -30,11 +30,10 @@ export class S3AttachmentsStorage {
   }
 
   async upload({
+    fileName,
     fileType,
     body,
   }: UploadParams): Promise<{id: string}> {
-    const fileName = randomUUID();
-
     await this.client.send(
       new PutObjectCommand({
         Bucket: this.config.get('STORAGE_BUCKET_NAME', { infer: true }),
@@ -58,7 +57,7 @@ export class S3AttachmentsStorage {
     return getSignedUrl(
       this.client,
       command,
-      { expiresIn: 60 * 60 }, // 1 hour expiration
+      { expiresIn: 60 * 60 * 24 }, // 24 hour expiration
     );
   }
 }

--- a/src/domain/product/core/errors/product-not-found.error.ts
+++ b/src/domain/product/core/errors/product-not-found.error.ts
@@ -1,0 +1,5 @@
+export class ProductNotFoundError extends Error {
+  constructor(id: string) {
+    super(`Product with ID "${id}" not found.`);
+  }
+}

--- a/src/domain/product/core/use-cases/create-product.use-case.ts
+++ b/src/domain/product/core/use-cases/create-product.use-case.ts
@@ -84,6 +84,10 @@ export class CreateProductUseCase {
       productId: product.id,
     }));
 
+    if (!coverPhotoId) {
+      product.coverPhotoId = productPhotos[0].attachmentId;
+    }
+
     product.photos = new ProductPhotosList(productPhotos);
 
     await this.productsRepository.save(product);

--- a/src/domain/product/core/use-cases/get-product-by-id.use-case.ts
+++ b/src/domain/product/core/use-cases/get-product-by-id.use-case.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+import { Either, left, right } from '@/domain/_shared/utils/either';
+import { PrismaProductsRepository } from '../../persistence/prisma/repositories/prisma-products.repository';
+import { ProductNotFoundError } from '../errors/product-not-found.error';
+import { S3AttachmentsStorage } from '@/domain/_shared/attachments/persistence/storage/s3-attachments.storage';
+
+export interface GetProductByIdInput {
+  id: string;
+}
+
+export interface GetProductByIdOutput {
+  id: string;
+  title: string;
+  description: string;
+  priceInCents: number;
+  categoryId: number;
+  stock: number;
+  likesCount: number;
+  averageRating: number;
+  photos: string[];
+  coverPhoto: string;
+}
+
+type Output = Either<Error, GetProductByIdOutput>;
+
+@Injectable()
+export class GetProductByIdUseCase {
+  constructor(
+    private readonly productsRepository: PrismaProductsRepository,
+    private readonly s3AttachmentStorage: S3AttachmentsStorage,
+  ) {}
+
+  async execute({
+    id,
+  }: GetProductByIdInput): Promise<Output> {
+    const product = await this.productsRepository.findById(id);
+
+    if (!product) {
+      return left(new ProductNotFoundError(id));
+    }
+
+    const urlPhotos = await Promise.all(
+      product
+        .photos!
+        .getItems()
+        .map((photo) => this.s3AttachmentStorage.getUrlByFileName(photo.attachmentId)),
+    );
+
+    const urlCoverPhoto = await this.s3AttachmentStorage.getUrlByFileName(product.coverPhotoId!);
+
+    return right({
+      id: product.id,
+      title: product.title,
+      description: product.description,
+      priceInCents: product.priceInCents,
+      categoryId: product.categoryId,
+      stock: product.stock,
+      likesCount: product.likesCount,
+      averageRating: product.averageRating ?? 0,
+      photos: urlPhotos,
+      coverPhoto: urlCoverPhoto,
+    });
+  }
+}

--- a/src/domain/product/http/controllers/get-product-by-id.controller.ts
+++ b/src/domain/product/http/controllers/get-product-by-id.controller.ts
@@ -1,0 +1,38 @@
+import {
+  BadRequestException, Controller, Get, NotFoundException, Param, UseGuards,
+} from '@nestjs/common';
+import { RolesGuard } from '@/domain/_shared/auth/roles/roles.guard';
+import { Roles } from '@/domain/_shared/auth/decorators/roles.decorator';
+import { UserRole } from '@/domain/identity/core/entities/user.entity';
+import { GetProductByIdUseCase } from '../../core/use-cases/get-product-by-id.use-case';
+import { ProductIdParamDto } from '../dtos/product-id-param.dto';
+import { ProductNotFoundError } from '../../core/errors/product-not-found.error';
+
+@Controller('products/:id')
+@UseGuards(RolesGuard)
+export class GetProductByIdController {
+  constructor(
+    private readonly getProductByIdUseCase: GetProductByIdUseCase,
+  ) {}
+
+  @Get()
+  @Roles(UserRole.ARTISAN)
+  async handle(
+    @Param() param: ProductIdParamDto,
+  ) {
+    const result = await this.getProductByIdUseCase.execute({ ...param });
+
+    if (result.isLeft()) {
+      const error = result.value;
+
+      switch (error.constructor) {
+        case ProductNotFoundError:
+          throw new NotFoundException(error.message);
+        default:
+          throw new BadRequestException(error.message);
+      }
+    }
+
+    return result.value;
+  }
+}

--- a/src/domain/product/http/dtos/product-id-param.dto.ts
+++ b/src/domain/product/http/dtos/product-id-param.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class ProductIdParamDto {
+  @IsUUID()
+    id: string;
+}

--- a/src/domain/product/http/http.module.ts
+++ b/src/domain/product/http/http.module.ts
@@ -2,14 +2,19 @@ import { Module } from '@nestjs/common';
 import { CreateProductController } from './controllers/create-product.controller';
 import { ProductPersistenceModule } from '../persistence/product-persistence.module';
 import { CreateProductUseCase } from '../core/use-cases/create-product.use-case';
+import { GetProductByIdUseCase } from '../core/use-cases/get-product-by-id.use-case';
+import { AttachmentPersistenceModule } from '@/domain/_shared/attachments/persistence/attachment-persistence.module';
+import { GetProductByIdController } from './controllers/get-product-by-id.controller';
 
 @Module({
-  imports: [ProductPersistenceModule],
+  imports: [ProductPersistenceModule, AttachmentPersistenceModule],
   controllers: [
     CreateProductController,
+    GetProductByIdController,
   ],
   providers: [
     CreateProductUseCase,
+    GetProductByIdUseCase,
   ],
 })
 export class HttpModule {}


### PR DESCRIPTION
This pull request introduces a new feature to retrieve product details by ID, including cover and photo URLs, and makes several related improvements and fixes. The main changes include implementing the "get product by ID" use case, its HTTP controller, error handling, and some updates to attachment handling and configuration files.

**Product retrieval feature:**

- Added `GetProductByIdUseCase` to fetch product details by ID, returning photo and cover photo URLs from S3 storage, and handling the case when the product is not found. (`src/domain/product/core/use-cases/get-product-by-id.use-case.ts`)
- Introduced `ProductNotFoundError` for clear error messaging when a product is not found. (`src/domain/product/core/errors/product-not-found.error.ts`)
- Added `GetProductByIdController` with route protection and error mapping to HTTP responses. (`src/domain/product/http/controllers/get-product-by-id.controller.ts`)
- Created `ProductIdParamDto` for validating the product ID parameter as a UUID. (`src/domain/product/http/dtos/product-id-param.dto.ts`)
- Registered new use case, controller, and required modules in `HttpModule`. (`src/domain/product/http/http.module.ts`)

**Attachment and S3 storage improvements:**

- Refactored attachment upload to use the `Attachment` entity's generated ID as the S3 file name, ensuring consistency between storage and database. (`src/domain/_shared/attachments/core/use-cases/upload-attachment.use-case.ts`, `src/domain/_shared/attachments/persistence/storage/s3-attachments.storage.ts`) [[1]](diffhunk://#diff-98ca17dd7d12a678c9ef631e5cc6bc510aa4b133049716da8f61edff97d5a16cL36-R45) [[2]](diffhunk://#diff-5fdb1a49d640305ff78f8a4bb32295b1e5d833e6ee461a21daa16eec660eebc0L4-R8) [[3]](diffhunk://#diff-5fdb1a49d640305ff78f8a4bb32295b1e5d833e6ee461a21daa16eec660eebc0R33-L37)
- Increased S3 signed URL expiration from 1 hour to 24 hours for better usability. (`src/domain/_shared/attachments/persistence/storage/s3-attachments.storage.ts`)

**Product creation logic:**

- Ensured that if no cover photo is specified during product creation, the first photo is used as the cover photo by default. (`src/domain/product/core/use-cases/create-product.use-case.ts`)

**Configuration file corrections:**

- Fixed environment variable names and formatting in `.env.example` for PostgreSQL and MinIO configuration. (`.env.example`) [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL6-R6) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL16-R16)