### PR TITLE
feat: Update productsCount in ArtisanProfile after saving a product

### DIFF
--- a/src/domain/product/persistence/prisma/repositories/prisma-products.repository.ts
+++ b/src/domain/product/persistence/prisma/repositories/prisma-products.repository.ts
@@ -118,5 +118,14 @@ export class PrismaProductsRepository {
         ]);
       }
     });
+
+    const countProductByArtisan = await this.prisma.product.count({
+      where: { artisanId: productData.artisanId },
+    });
+
+    await this.prisma.artisanProfile.update({
+      where: { userId: product.artisanId },
+      data: { productsCount: countProductByArtisan },
+    });
   }
 }


### PR DESCRIPTION
This pull request updates the product creation logic to ensure that the `productsCount` field in the `artisanProfile` entity stays in sync with the actual number of products an artisan has. Now, after a product is created, the code recalculates and updates the artisan's product count.

**Product count synchronization:**

* After creating a product, the code now counts the number of products associated with the artisan (`artisanId`) and updates the `productsCount` field in the corresponding `artisanProfile` record to reflect the new total.