### PR TITLE
fix: return username on login

### DIFF
--- a/src/domain/identity/core/use-cases/authenticate.use-case.ts
+++ b/src/domain/identity/core/use-cases/authenticate.use-case.ts
@@ -5,6 +5,7 @@ import { Either, left, right } from '@/domain/_shared/utils/either';
 import { InvalidCredentialsError } from '../errors/invalid-credentials.error';
 import { UserRole } from '../entities/user.entity';
 import { PrismaUsersRepository } from '../../persistence/prisma/repositories/prisma-users.repository';
+import { PrismaArtisanProfilesRepository } from '../../persistence/prisma/repositories/prisma-artisan-profiles.repository';
 
 export interface AuthenticateInput {
   email: string;
@@ -17,6 +18,7 @@ export interface AuthenticateOutput {
   userId: string;
   name: string;
   socialName?: string;
+  artisanUserName?: string;
 }
 
 type Output = Either<InvalidCredentialsError, AuthenticateOutput>
@@ -25,6 +27,7 @@ type Output = Either<InvalidCredentialsError, AuthenticateOutput>
 export class AuthenticateUseCase {
   constructor(
     private readonly usersRepository: PrismaUsersRepository,
+    private readonly artisanProfileRepository: PrismaArtisanProfilesRepository,
     private readonly jwt: JwtService,
   ) {}
 
@@ -45,6 +48,16 @@ export class AuthenticateUseCase {
       return left(new InvalidCredentialsError());
     }
 
+    let artisanUserName: string | undefined;
+
+    if (user.roles.includes(UserRole.ARTISAN)) {
+      const artisanProfile = await this.artisanProfileRepository.findByUserId(user.id);
+
+      console.log('Artisan profile found:', artisanProfile);
+
+      artisanUserName = artisanProfile!.userName;
+    }
+
     const accessToken = this.jwt.sign({ sub: user.id, roles: user.roles });
 
     return right({
@@ -53,6 +66,7 @@ export class AuthenticateUseCase {
       userId: user.id,
       name: user.name,
       socialName: user.socialName,
+      artisanUserName,
     });
   }
 }

--- a/src/domain/identity/core/use-cases/authenticate.use-case.ts
+++ b/src/domain/identity/core/use-cases/authenticate.use-case.ts
@@ -53,8 +53,6 @@ export class AuthenticateUseCase {
     if (user.roles.includes(UserRole.ARTISAN)) {
       const artisanProfile = await this.artisanProfileRepository.findByUserId(user.id);
 
-      console.log('Artisan profile found:', artisanProfile);
-
       artisanUserName = artisanProfile!.userName;
     }
 

--- a/src/domain/identity/http/controllers/authenticate.controller.ts
+++ b/src/domain/identity/http/controllers/authenticate.controller.ts
@@ -42,6 +42,7 @@ export class AuthenticateController {
       userId: result.value.userId,
       name: result.value.name,
       socialName: result.value.socialName,
+      artisanUserName: result.value.artisanUserName,
     });
   }
 }


### PR DESCRIPTION
This pull request enhances the authentication flow to include artisan-specific information when applicable. The main change is that, for users with the `ARTISAN` role, the system now fetches and returns the artisan's username as part of the authentication response. This required extending both the use case and controller, as well as injecting a new repository dependency.

**Authentication logic improvements:**

* Updated the `AuthenticateUseCase` to inject the `PrismaArtisanProfilesRepository` and, when the authenticated user has the `ARTISAN` role, fetch and include the associated `artisanUserName` in the authentication output. [[1]](diffhunk://#diff-cc25ba58431e0ff70ab65e5e1319ffb1c50d334de57333f32eb2415c451c75e3R8) [[2]](diffhunk://#diff-cc25ba58431e0ff70ab65e5e1319ffb1c50d334de57333f32eb2415c451c75e3R30) [[3]](diffhunk://#diff-cc25ba58431e0ff70ab65e5e1319ffb1c50d334de57333f32eb2415c451c75e3R51-R58) [[4]](diffhunk://#diff-cc25ba58431e0ff70ab65e5e1319ffb1c50d334de57333f32eb2415c451c75e3R67)

**API contract changes:**

* Extended the `AuthenticateOutput` interface and controller response to include the new optional `artisanUserName` property, ensuring clients receive this information when relevant. [[1]](diffhunk://#diff-cc25ba58431e0ff70ab65e5e1319ffb1c50d334de57333f32eb2415c451c75e3R21) [[2]](diffhunk://#diff-538bc0202762c4a95f67fe34464da6661986494cf00be6876c8c8dc703b2137dR45)