### PR TITLE
Issue#65

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.864.0",
         "@aws-sdk/s3-request-presigner": "^3.864.0",
-        "@faker-js/faker": "^9.9.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.1",
         "@nestjs/core": "^11.0.1",
@@ -33,6 +32,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
+        "@faker-js/faker": "^9.9.0",
         "@nestjs/cli": "^11.0.0",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
@@ -1659,6 +1659,7 @@
       "version": "9.9.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
       "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "prisma:seed": "ts-node prisma/seed.ts",
+    "db:clean": "npx tsx scripts/dev/clean-database.ts",
     "build": "nest build",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.864.0",
     "@aws-sdk/s3-request-presigner": "^3.864.0",
-    "@faker-js/faker": "^9.9.0",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.1",
     "@nestjs/core": "^11.0.1",
@@ -41,6 +40,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.9.0",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
     "@nestjs/cli": "^11.0.0",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -15,6 +15,7 @@ import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
+import { hash } from 'bcryptjs';
 
 const prisma = new PrismaClient();
 
@@ -49,7 +50,7 @@ async function main() {
     const user = await prisma.user.create({
       data: {
         email: faker.internet.email(),
-        password: 'senhaPadrao123',
+        password: await hash('senhaPadrao123', 10),
         role: [faker.helpers.arrayElement(roles)],
       },
     });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -16,11 +16,17 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomUUID } from 'crypto';
 import { hash } from 'bcryptjs';
+import { cleanDatabase } from '../scripts/dev/clean-database';
 
 const prisma = new PrismaClient();
 
 async function main() {
   console.log('Seed: starting...');
+
+  // Limpando banco
+  await cleanDatabase();
+  console.log('Banco de dados limpo');
+
   // Criar categorias de produto
   const categories = await prisma.productCategory.createMany({
     data: [

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -243,10 +243,10 @@ async function main() {
   } catch (err) {
     // não falha o seed se o MinIO não estiver disponível — apenas log
     // eslint-disable-next-line no-console
-    console.warn('Seed: não foi possível fazer upload das imagens para o storage:', err?.message ?? err);
+    console.warn('Seed: could not upload images to storage:', err?.message ?? err);
   }
+  console.log('Seed: finished.');
 }
-console.log('Seed: finished.');
 
 main()
   .catch((e) => {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -38,12 +38,13 @@ async function main() {
   for (const role of roles) {
     const user = await prisma.user.create({
       data: {
-        email: faker.internet.email(),
-        password: faker.internet.password(),
+        email: `${role.toLowerCase()}@test.com`,
+        password: await hash('senhaPadrao123', 10),
         role: [role],
       },
     });
     users.push(user);
+    console.log(`Created user with email: ${user.email}`);
   }
   // Adiciona mais usuários aleatórios
   for (let i = 0; i < 2; i++) {
@@ -55,6 +56,7 @@ async function main() {
       },
     });
     users.push(user);
+    console.log(`Created user with email: ${user.email}`);
   }
 
   // Criar perfis de usuário

--- a/scripts/dev/clean-database.ts
+++ b/scripts/dev/clean-database.ts
@@ -1,0 +1,47 @@
+/* eslint-disable no-console */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function cleanDatabase() {
+  // Ordem importante devido às foreign keys
+  console.log(' Iniciando limpeza do banco de dados...');
+
+  await prisma.productLike.deleteMany();
+  console.log('✓ Likes de produtos removidos');
+
+  await prisma.productRating.deleteMany();
+  console.log('✓ Avaliações de produtos removidas');
+
+  await prisma.attachment.deleteMany();
+  console.log('✓ Anexos removidos');
+
+  await prisma.product.deleteMany();
+  console.log('✓ Produtos removidos');
+
+  await prisma.artisanApplication.deleteMany();
+  console.log('✓ Solicitações de artesão removidas');
+
+  await prisma.artisanProfile.deleteMany();
+  console.log('✓ Perfis de artesão removidos');
+
+  await prisma.userProfile.deleteMany();
+  console.log('✓ Perfis de usuário removidos');
+
+  await prisma.user.deleteMany();
+  console.log('✓ Usuários removidos');
+
+  await prisma.productCategory.deleteMany();
+  console.log('✓ Categorias de produtos removidas');
+
+  console.log(' Banco de dados limpo com sucesso!');
+}
+
+cleanDatabase()
+  .catch((e) => {
+    console.error('❌ Erro ao limpar banco:', e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/domain/product/core/errors/not-allowed.error.ts
+++ b/src/domain/product/core/errors/not-allowed.error.ts
@@ -1,0 +1,5 @@
+export class NotAllowedError extends Error {
+  constructor() {
+    super('You are not allowed to perform this action.');
+  }
+}

--- a/src/domain/product/core/errors/product-already-inactive.error.ts
+++ b/src/domain/product/core/errors/product-already-inactive.error.ts
@@ -1,0 +1,5 @@
+export class ProductAlreadyInactiveError extends Error {
+  constructor(id: string) {
+    super(`Product with ID "${id}" is already inactive.`);
+  }
+}

--- a/src/domain/product/core/use-cases/deactivate-product.use-case.ts
+++ b/src/domain/product/core/use-cases/deactivate-product.use-case.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { Either, left, right } from '@/domain/_shared/utils/either';
+import { PrismaProductsRepository } from '../../persistence/prisma/repositories/prisma-products.repository';
+import { ProductNotFoundError } from '../errors/product-not-found.error';
+import { NotAllowedError } from '../errors/not-allowed.error';
+import { ProductAlreadyInactiveError } from '../errors/product-already-inactive.error';
+
+export interface DeactivateProductInput {
+    productId: string;
+    requesterId: string;
+}
+
+type Output = Either<
+    ProductNotFoundError | NotAllowedError | ProductAlreadyInactiveError,
+    { message: string}
+>;
+
+@Injectable()
+export class DeactivateProductUseCase {
+  constructor(private readonly productsRepository: PrismaProductsRepository) {}
+
+  async execute({ productId, requesterId }: DeactivateProductInput): Promise<Output> {
+    const product = await this.productsRepository.findById(productId);
+
+    if (!product) {
+      return left(new ProductNotFoundError(productId));
+    }
+
+    if (product.artisanId !== requesterId) {
+      return left(new NotAllowedError());
+    }
+
+    const alreadyInactive = await this.productsRepository.isDisabled(productId);
+
+    if (alreadyInactive) {
+      return left(new ProductAlreadyInactiveError(productId));
+    }
+
+    await this.productsRepository.deactivate(productId);
+    return right({ message: 'Product deactivated successfully' });
+  }
+}

--- a/src/domain/product/http/controllers/product.delete.controller.ts
+++ b/src/domain/product/http/controllers/product.delete.controller.ts
@@ -24,6 +24,7 @@ export class DeleteProductController {
     const result = await this.deleteProductUseCase.execute({
       productId: id,
       requesterId: user.sub,
+      requesterRole: user.roles,
     });
 
     if (result.isLeft()) {

--- a/src/domain/product/http/controllers/product.delete.controller.ts
+++ b/src/domain/product/http/controllers/product.delete.controller.ts
@@ -1,0 +1,45 @@
+import {
+  Controller, Delete, Param, UseGuards, ForbiddenException, NotFoundException, ConflictException,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '@/domain/_shared/auth/jwt/jwt-auth.guard';
+import { RolesGuard } from '@/domain/_shared/auth/roles/roles.guard';
+import { Roles } from '@/domain/_shared/auth/decorators/roles.decorator';
+import { CurrentUser } from '@/domain/_shared/auth/decorators/current-user.decorator';
+import { UserPayload } from '@/domain/_shared/auth/jwt/jwt.strategy';
+import { UserRole } from '@/domain/identity/core/entities/user.entity';
+import { DeactivateProductUseCase } from '@/domain/product/core/use-cases/deactivate-product.use-case';
+import { ProductIdParamDto } from '@/domain/product/http/dtos/product-id-param.dto';
+import { ProductNotFoundError } from '../../core/errors/product-not-found.error';
+import { NotAllowedError } from '../../core/errors/not-allowed.error';
+import { ProductAlreadyInactiveError } from '../../core/errors/product-already-inactive.error';
+
+@Controller('products')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class DeleteProductController {
+  constructor(private readonly deleteProductUseCase: DeactivateProductUseCase) {}
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN, UserRole.ARTISAN)
+  async handle(@Param() { id } : ProductIdParamDto, @CurrentUser() user: UserPayload) {
+    const result = await this.deleteProductUseCase.execute({
+      productId: id,
+      requesterId: user.sub,
+    });
+
+    if (result.isLeft()) {
+      const error = result.value;
+      if (error instanceof ProductNotFoundError) {
+        throw new NotFoundException(error.message);
+      }
+      if (error instanceof NotAllowedError) {
+        throw new ForbiddenException(error.message);
+      }
+      if (error instanceof ProductAlreadyInactiveError) {
+        throw new ConflictException(error.message);
+      }
+      throw error;
+    }
+
+    return { message: 'Product deleted successfully' };
+  }
+}

--- a/src/domain/product/http/http.module.ts
+++ b/src/domain/product/http/http.module.ts
@@ -8,6 +8,8 @@ import { GetProductByIdController } from './controllers/get-product-by-id.contro
 import { IdentityPersistenceModule } from '@/domain/identity/persistence/identity-persistence.module';
 import { ListProductsController } from './controllers/list-products.controller';
 import { ListProductsUseCase } from '../core/use-cases/list-products.use-case';
+import { DeleteProductController } from './controllers/product.delete.controller';
+import { DeactivateProductUseCase } from '../core/use-cases/deactivate-product.use-case';
 
 @Module({
   imports: [ProductPersistenceModule, AttachmentPersistenceModule, IdentityPersistenceModule],
@@ -15,11 +17,13 @@ import { ListProductsUseCase } from '../core/use-cases/list-products.use-case';
     CreateProductController,
     GetProductByIdController,
     ListProductsController,
+    DeleteProductController,
   ],
   providers: [
     CreateProductUseCase,
     GetProductByIdUseCase,
     ListProductsUseCase,
+    DeactivateProductUseCase,
   ],
 })
 export class HttpModule {}

--- a/src/domain/product/persistence/prisma/repositories/prisma-products.repository.ts
+++ b/src/domain/product/persistence/prisma/repositories/prisma-products.repository.ts
@@ -140,4 +140,18 @@ export class PrismaProductsRepository {
       ),
     ]);
   }
+
+  async isDisabled(productId: string): Promise<boolean> {
+    const product = await this.prisma.product.findUnique({
+      where: { id: productId },
+    });
+    return !!product?.isDisabled;
+  }
+
+  async deactivate(productId: string): Promise<void> {
+    await this.prisma.product.update({
+      where: { id: productId },
+      data: { isDisabled: true },
+    });
+  }
 }


### PR DESCRIPTION
This pull request introduces a new feature for soft-deleting (deactivating) products, including all necessary backend logic, error handling, and controller endpoints. It also adds a utility script for cleaning the database and improves the seeding process for local development.

**Product Deactivation Feature**

* Added `DeactivateProductUseCase` to encapsulate the logic for deactivating a product, including permission checks and error handling.
* Implemented `DeleteProductController` to expose the new deactivation endpoint, mapping domain errors to appropriate HTTP responses.
* Extended `PrismaProductsRepository` with `isDisabled` and `deactivate` methods to support soft-deletion of products in the database.
* Registered the new use case and controller in the product HTTP module.
* Introduced domain errors: `NotAllowedError` and `ProductAlreadyInactiveError` for precise error reporting. [[1]](diffhunk://#diff-dd9b9dcc1b0290229ab7865d318263ea25e0a6825501b063aa359cf94c5073a5R1-R5) [[2]](diffhunk://#diff-a9aba30cb5f6409e974e4bb6814e8b3075a5f10b924103ced551267314b94477R1-R5)

**Development Utilities**

* Added a `clean-database.ts` script to remove all data from the database in the correct order; exposed via a new npm script `db:clean`. [[1]](diffhunk://#diff-44bc29574477c8df3b70a2f8b9102353fd118f206fd532cff9303ac45f511345R1-R47) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R10)
* Updated the seed script to use the new cleaning utility and improved user creation for more predictable test accounts and output. [[1]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR19-R29) [[2]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bL41-R53) [[3]](diffhunk://#diff-25916e4beee74957726a7a074b682a3761a114d8115673d94cec96579c58d05bR65)
* 
closes #65 