### PR TITLE
Refactor matching category logic

### DIFF
--- a/src/domain/products/core/use-cases/create-product.use-case.ts
+++ b/src/domain/products/core/use-cases/create-product.use-case.ts
@@ -166,19 +166,23 @@ export class CreateProductUseCase {
     techniqueIds: number[],
   ) {
     const matchingCategories = categories.map((categorie) => {
-      const categoryRawMaterialIds = categorie.rawMaterialIds.map((id) => Number(id));
-      const categoryTechniqueIds = categorie.techniqueIds.map((id) => Number(id));
+      const categoryRawMaterialIds = categorie.rawMaterialIds.map((id) => id);
+      const categoryTechniqueIds = categorie.techniqueIds.map((id) => id);
 
-      const hasAnyRawMaterial = rawMaterialIds.some((id) => categoryRawMaterialIds.includes(id));
-      const hasAnyTechnique = techniqueIds.some((id) => categoryTechniqueIds.includes(id));
+      const hasAnyRawMaterial = rawMaterialIds.some(
+        (id) => categoryRawMaterialIds.includes(BigInt(id)),
+      );
+      const hasAnyTechnique = techniqueIds.some(
+        (id) => categoryTechniqueIds.includes(BigInt(id)),
+      );
 
-      if (hasAnyRawMaterial && hasAnyTechnique) {
+      if (hasAnyRawMaterial || hasAnyTechnique) {
         return categorie;
       }
-      return null;
+      return undefined;
     });
 
-    return matchingCategories;
+    return matchingCategories.splice(0).filter((c) => c !== undefined);
   }
 
   private async validateAndLinkAttachments(


### PR DESCRIPTION
This pull request updates the category-matching logic in the `CreateProductUseCase` to improve how categories are selected based on raw material and technique IDs. The main changes involve switching from number to BigInt comparisons and adjusting the matching criteria to be more inclusive.

**Category matching logic improvements:**

* Changed the comparison of `rawMaterialIds` and `techniqueIds` against category IDs from `Number` to `BigInt` to ensure type consistency and correct matching.
* Updated the matching condition from requiring both a raw material and a technique match (`&&`) to allowing a match if either is present (`||`), making category selection more inclusive.
* Changed the return value for non-matching categories from `null` to `undefined` and filtered them out of the result, ensuring the returned array only contains valid matches.