### PR TITLE
Add image_path column to product_categories

### DIFF
--- a/prisma/migrations/20251013120212_add_image_path_to_category/migration.sql
+++ b/prisma/migrations/20251013120212_add_image_path_to_category/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "product_categories" ADD COLUMN     "image_path" TEXT;

--- a/src/domain/products/core/use-cases/get-product-by-id.use-case.ts
+++ b/src/domain/products/core/use-cases/get-product-by-id.use-case.ts
@@ -24,6 +24,7 @@ export interface GetProductByIdOutput {
   likesCount: number;
   averageRating: number;
   photos: string[];
+  photosIds: string[];
   coverPhoto?: string;
 }
 
@@ -95,6 +96,7 @@ export class GetProductByIdUseCase {
         likesCount: product.likesCount,
         averageRating: product.averageRating ?? 0,
         photos,
+        photosIds: product.photos ? product.photos.map((p) => p.attachmentId) : [],
         coverPhoto,
       });
     } catch (error) {


### PR DESCRIPTION
This pull request introduces a new field to the product categories database table and enhances the product details returned by the `GetProductByIdUseCase`. The main improvements are the addition of an `image_path` column for product categories and the inclusion of photo IDs in the product details output.

**Database schema changes:**

* Added a new `image_path` column of type `TEXT` to the `product_categories` table to store image paths for categories.

**Product details API enhancements:**

* Updated the `GetProductByIdOutput` interface to include a new `photosIds` field, which is an array of photo attachment IDs.
* Modified the `GetProductByIdUseCase` class to populate the `photosIds` field by mapping over the product's photos and extracting their `attachmentId` values.