### PR TITLE
Implement GetArtisanProfileByUsername use case and controller

### DIFF
--- a/src/domain/identity/core/use-cases/get-artisan-profile-by-username.use-case.ts
+++ b/src/domain/identity/core/use-cases/get-artisan-profile-by-username.use-case.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Either, left, right } from '@/domain/_shared/utils/either';
+import { UserNotFoundError } from '../errors/user-not-found.error';
+import { ArtisanProfileNotFoundError } from '../errors/artisan-profile-not-found.error';
+import { ArtisanProfilesRepository } from '@/domain/repositories/artisan-profiles.repository';
+import { UsersRepository } from '@/domain/repositories/users.repository';
+import { S3StorageService } from '@/domain/attachments/s3-storage.service';
+
+export interface GetArtisanProfileByUsernameInput {
+  username: string;
+}
+
+export interface GetArtisanProfileByUsernameOutput {
+  userId: string;
+  artisanName: string;
+  userName: string;
+  socialName: string | null;
+  followersCount: number;
+  productsCount: number;
+  phoneNumber: string;
+  bio: string | null;
+  avatar: string | null;
+}
+
+type Output = Either<
+  ArtisanProfileNotFoundError | UserNotFoundError,
+  GetArtisanProfileByUsernameOutput
+>;
+
+@Injectable()
+export class GetArtisanProfileByUsernameUseCase {
+  private readonly logger = new Logger(GetArtisanProfileByUsernameUseCase.name);
+
+  constructor(
+    private readonly artisanProfileRepository: ArtisanProfilesRepository,
+    private readonly usersRepository: UsersRepository,
+    private readonly s3StorageService: S3StorageService,
+  ) {}
+
+  async execute({ username }: GetArtisanProfileByUsernameInput): Promise<Output> {
+    try {
+      this.logger.debug(`Fetching artisan profile for username: ${username}`);
+
+      const artisanProfile = await this
+        .artisanProfileRepository
+        .findByUserName(username);
+
+      if (!artisanProfile) {
+        this.logger.warn(`Artisan profile not found for username: ${username}`);
+        return left(new ArtisanProfileNotFoundError(username));
+      }
+
+      this.logger.debug(`Found artisan profile for user ID: ${artisanProfile.userId}`);
+
+      const user = await this.usersRepository.findById(artisanProfile.userId);
+
+      if (!user) {
+        this.logger.warn(`User not found for ID: ${artisanProfile.userId}`);
+        return left(new UserNotFoundError(artisanProfile.userId, 'id'));
+      }
+
+      const avatar = await this.generateAvatarUrl(user.avatar);
+
+      this.logger.debug(`Successfully retrieved profile for username: ${username}`);
+
+      return right({
+        userId: artisanProfile.userId,
+        artisanName: user.name,
+        userName: artisanProfile.artisanUserName,
+        socialName: user.socialName ?? null,
+        followersCount: artisanProfile.followersCount,
+        productsCount: artisanProfile.productsCount,
+        phoneNumber: user.phone,
+        bio: artisanProfile.bio,
+        avatar,
+      });
+    } catch (error) {
+      this.logger.error(`Error getting artisan profile by username: ${username}`, error);
+      return left(new ArtisanProfileNotFoundError(username));
+    }
+  }
+
+  private async generateAvatarUrl(avatarId: string | null): Promise<string | null> {
+    if (!avatarId) {
+      return null;
+    }
+
+    try {
+      const url = await this.s3StorageService.getUrlByFileName(avatarId);
+      this.logger.debug(`Generated avatar URL for attachment: ${avatarId}`);
+      return url;
+    } catch (urlError) {
+      this.logger.warn(`Failed to generate avatar URL for attachment ${avatarId}:`, urlError);
+      return null;
+    }
+  }
+}

--- a/src/domain/identity/http/controllers/get-artisan-profile-by-username.controller.ts
+++ b/src/domain/identity/http/controllers/get-artisan-profile-by-username.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Controller,
+  Get,
+  Param,
+  UseGuards,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '@/domain/_shared/auth/jwt/jwt-auth.guard';
+import { GetArtisanProfileByUsernameUseCase } from '../../core/use-cases/get-artisan-profile-by-username.use-case';
+import { UserNotFoundError } from '../../core/errors/user-not-found.error';
+
+@Controller('artisan-profiles/:username')
+@UseGuards(JwtAuthGuard)
+export class GetArtisanProfileByUsernameController {
+  constructor(
+    private readonly getArtisanProfileByUsername: GetArtisanProfileByUsernameUseCase,
+  ) {}
+
+  @Get()
+  async handleOwn(
+    @Param('username') username: string,
+  ) {
+    const result = await this.getArtisanProfileByUsername.execute({
+      username,
+    });
+
+    if (result.isLeft()) {
+      const error = result.value;
+
+      switch (error.constructor) {
+        case UserNotFoundError:
+          throw new NotFoundException(error.message);
+        default:
+          throw new BadRequestException(error.message);
+      }
+    }
+
+    return result.value;
+  }
+}

--- a/src/domain/identity/http/http.module.ts
+++ b/src/domain/identity/http/http.module.ts
@@ -17,6 +17,8 @@ import { GetArtisanApplicationDetailsController } from './controllers/get-artisa
 import { InitiateArtisanApplicationController } from './controllers/initiate-artisan-application.controller';
 import { ModerateArtisanApplicationController } from './controllers/moderate-artisan-application.controller';
 import { SearchUsersController } from './controllers/search-users.controller';
+import { GetArtisanProfileByUsernameController } from './controllers/get-artisan-profile-by-username.controller';
+import { GetArtisanProfileByUsernameUseCase } from '../core/use-cases/get-artisan-profile-by-username.use-case';
 
 @Module({
   imports: [RepositoriesModule, AttachmentsModule],
@@ -26,6 +28,7 @@ import { SearchUsersController } from './controllers/search-users.controller';
     CreateUserController,
     GetAllArtisanApplicationsController,
     GetArtisanApplicationDetailsController,
+    GetArtisanProfileByUsernameController,
     InitiateArtisanApplicationController,
     ModerateArtisanApplicationController,
     SearchUsersController,
@@ -35,6 +38,7 @@ import { SearchUsersController } from './controllers/search-users.controller';
     CompleteArtisanApplicationUseCase,
     CreateUserUseCase,
     GetAllArtisanApplicationsUseCase,
+    GetArtisanProfileByUsernameUseCase,
     GetArtisanApplicationDetailsUseCase,
     InitiateArtisanApplicationUseCase,
     ModerateArtisanApplicationUseCase,

--- a/src/domain/products/http/controllers/update-product.controller.ts
+++ b/src/domain/products/http/controllers/update-product.controller.ts
@@ -29,10 +29,16 @@ export class UpdateProductController {
       throw new BadRequestException('Invalid request body');
     }
 
+    const updateBody = { ...body };
+
+    if (updateBody.coverPhotoId === '' || updateBody.coverPhotoId === null) {
+      updateBody.coverPhotoId = undefined;
+    }
+
     const result = await this.updateProductUseCase.execute({
       productId: param.id,
       authorId: user.sub,
-      ...body,
+      ...updateBody,
     });
 
     if (result.isLeft()) {


### PR DESCRIPTION
This pull request introduces a new feature that allows fetching an artisan profile by username, including both the core use case and the HTTP controller. Additionally, it registers these new components in the module configuration. There is also a minor fix to the product update controller to handle empty or null cover photo IDs more robustly.

**New Feature: Get Artisan Profile by Username**
- Added `GetArtisanProfileByUsernameUseCase` to encapsulate the logic for retrieving an artisan's profile by username, including error handling and avatar URL resolution (`src/domain/identity/core/use-cases/get-artisan-profile-by-username.use-case.ts`).
- Introduced `GetArtisanProfileByUsernameController` to expose the new use case via an authenticated GET endpoint (`src/domain/identity/http/controllers/get-artisan-profile-by-username.controller.ts`).
- Registered the new controller and use case in the module providers and controllers arrays (`src/domain/identity/http/http.module.ts`). [[1]](diffhunk://#diff-4a3d6b518f5f8aaee6e65d5a79c081c2e201c11ee1b85ce635c23ae51cec7f41R20-R21) [[2]](diffhunk://#diff-4a3d6b518f5f8aaee6e65d5a79c081c2e201c11ee1b85ce635c23ae51cec7f41R31) [[3]](diffhunk://#diff-4a3d6b518f5f8aaee6e65d5a79c081c2e201c11ee1b85ce635c23ae51cec7f41R41)

**Bug Fix: Product Update Handling**
- Improved the `UpdateProductController` to ensure that if the `coverPhotoId` is empty or null, it is set to `undefined` before passing to the use case, preventing unintended updates (`src/domain/products/http/controllers/update-product.controller.ts`).