### PR TITLE
Implement GetMyProfile use case and controller for user profile 

### DIFF
--- a/src/domain/identity/core/use-cases/get-my-profile.use-case.ts
+++ b/src/domain/identity/core/use-cases/get-my-profile.use-case.ts
@@ -1,0 +1,116 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Either, left, right } from '@/domain/_shared/utils/either';
+import { UserNotFoundError } from '../errors/user-not-found.error';
+import { UsersRepository } from '@/domain/repositories/users.repository';
+import { ArtisanProfilesRepository } from '@/domain/repositories/artisan-profiles.repository';
+import { S3StorageService } from '@/domain/attachments/s3-storage.service';
+
+export interface GetMyProfileInput {
+  userId: string;
+  userRoles: string[];
+}
+
+export interface GetMyProfileOutput {
+  id: string;
+  name: string;
+  socialName?: string | null;
+  phone: string;
+  email: string;
+  avatar?: string | null;
+  artisanUserName?: string;
+  bio?: string | null;
+  sicab?: string;
+  sicabRegistrationDate?: Date | null;
+  sicabValidUntil?: Date | null;
+  followersCount?: number;
+  productsCount?: number;
+  rawMaterial?: string[];
+  technique?: string[];
+  finalityClassification?: string[];
+}
+
+type Output = Either<UserNotFoundError, { user: GetMyProfileOutput }>;
+
+@Injectable()
+export class GetMyProfileUseCase {
+  private readonly logger = new Logger(GetMyProfileUseCase.name);
+
+  constructor(
+    private readonly usersRepository: UsersRepository,
+    private readonly artisanProfilesRepository: ArtisanProfilesRepository,
+    private readonly s3AttachmentsStorage: S3StorageService,
+  ) {}
+
+  async execute({ userId, userRoles }: GetMyProfileInput): Promise<Output> {
+    try {
+      this.logger.debug(`Getting profile for user: ${userId}`);
+
+      const user = await this.usersRepository.findById(userId);
+
+      if (!user) {
+        this.logger.warn(`User not found: ${userId}`);
+        return left(new UserNotFoundError(userId, 'id'));
+      }
+
+      const avatar = await this.generateAvatarUrl(user.avatar);
+
+      const profileData: GetMyProfileOutput = {
+        id: user.id,
+        name: user.name,
+        socialName: user.socialName,
+        phone: user.phone,
+        email: user.email,
+        avatar,
+      };
+
+      if (userRoles.includes('ARTISAN')) {
+        this.logger.debug(`User is ARTISAN, fetching artisan profile for user: ${userId}`);
+
+        const artisanProfile = await this.artisanProfilesRepository.findByUserId(userId);
+
+        if (artisanProfile) {
+          this.logger.debug(`Found artisan profile for user: ${userId}`);
+
+          Object.assign(profileData, {
+            artisanUserName: artisanProfile.artisanUserName,
+            bio: artisanProfile.bio,
+            sicab: artisanProfile.sicab,
+            sicabRegistrationDate: artisanProfile.sicabRegistrationDate,
+            sicabValidUntil: artisanProfile.sicabValidUntil,
+            followersCount: artisanProfile.followersCount,
+            productsCount: artisanProfile.productsCount,
+            rawMaterial: artisanProfile.rawMaterial,
+            technique: artisanProfile.technique,
+            finalityClassification: artisanProfile.finalityClassification,
+          });
+        } else {
+          this.logger.warn(`Artisan profile not found for user: ${userId}`);
+        }
+      }
+
+      this.logger.debug(`Successfully retrieved profile for user: ${userId}`);
+
+      return right({
+        user: profileData,
+      });
+    } catch (error) {
+      this.logger.error(`Error getting profile for user ${userId}:`, error);
+      return left(new UserNotFoundError(userId, 'id'));
+    }
+  }
+
+  private async generateAvatarUrl(avatarId: string | null): Promise<string | null> {
+    if (!avatarId) {
+      return null;
+    }
+
+    try {
+      const url = await this.s3AttachmentsStorage.getUrlByFileName(avatarId);
+      this.logger.debug(`Generated avatar URL for attachment: ${avatarId}`);
+      return url;
+    } catch (urlError) {
+      this.logger.warn(`Failed to generate avatar URL for attachment ${avatarId}:`, urlError);
+      return null;
+    }
+  }
+}

--- a/src/domain/identity/http/controllers/get-my-profile.controller.ts
+++ b/src/domain/identity/http/controllers/get-my-profile.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Controller,
+  Get,
+  NotFoundException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+import { CurrentUser } from '@/domain/_shared/auth/decorators/current-user.decorator';
+import { UserNotFoundError } from '../../core/errors/user-not-found.error';
+import { GetMyProfileUseCase } from '../../core/use-cases/get-my-profile.use-case';
+import { TokenPayload } from '@/domain/_shared/auth/jwt/jwt.strategy';
+
+@Controller('users')
+export class GetMyProfileController {
+  constructor(
+    private readonly getMyProfileUseCase: GetMyProfileUseCase,
+  ) {}
+
+  @Get('me')
+  async handle(@CurrentUser() user: TokenPayload) {
+    const result = await this.getMyProfileUseCase.execute({
+      userId: user.sub,
+      userRoles: user.roles,
+    });
+
+    if (result.isLeft()) {
+      const error = result.value;
+
+      switch (error.constructor) {
+        case UserNotFoundError:
+          throw new NotFoundException(error.message);
+        default:
+          throw new InternalServerErrorException('Erro interno do servidor');
+      }
+    }
+
+    const { user: profileData } = result.value;
+
+    return {
+      message: 'Perfil recuperado com sucesso',
+      user: profileData,
+    };
+  }
+}

--- a/src/domain/identity/http/http.module.ts
+++ b/src/domain/identity/http/http.module.ts
@@ -22,6 +22,8 @@ import { GetArtisanProfileByUsernameUseCase } from '../core/use-cases/get-artisa
 import { UpdatePersonalProfileDataController } from './controllers/update-personal-profile-data.controller';
 import { UpdatePersonalProfileDataUseCase } from '../core/use-cases/update-personal-profile-data.use-case';
 import { UpdateArtisanProfileUseCase } from '../core/use-cases/update-artisan-profile.use-case';
+import { GetMyProfileController } from './controllers/get-my-profile.controller';
+import { GetMyProfileUseCase } from '../core/use-cases/get-my-profile.use-case';
 
 @Module({
   imports: [RepositoriesModule, AttachmentsModule],
@@ -32,6 +34,7 @@ import { UpdateArtisanProfileUseCase } from '../core/use-cases/update-artisan-pr
     GetAllArtisanApplicationsController,
     GetArtisanApplicationDetailsController,
     GetArtisanProfileByUsernameController,
+    GetMyProfileController,
     InitiateArtisanApplicationController,
     ModerateArtisanApplicationController,
     SearchUsersController,
@@ -44,6 +47,7 @@ import { UpdateArtisanProfileUseCase } from '../core/use-cases/update-artisan-pr
     GetAllArtisanApplicationsUseCase,
     GetArtisanProfileByUsernameUseCase,
     GetArtisanApplicationDetailsUseCase,
+    GetMyProfileUseCase,
     InitiateArtisanApplicationUseCase,
     ModerateArtisanApplicationUseCase,
     SearchUsersUseCase,


### PR DESCRIPTION
This pull request introduces a new feature that allows users to retrieve their own profile information via an authenticated endpoint. The main changes include the implementation of the `GetMyProfileUseCase` for fetching user and artisan profile data, a corresponding controller to expose this functionality, and the necessary updates to the module for dependency injection.

**New "Get My Profile" feature:**

* Added `GetMyProfileUseCase` to handle fetching user profile data, including artisan-specific fields when applicable, with support for avatar URL generation and error handling.
* Implemented `GetMyProfileController` with a new `GET /users/me` endpoint, providing structured error responses and returning the user's profile data.

**Module integration:**

* Registered `GetMyProfileController` and `GetMyProfileUseCase` in the `http.module.ts` to enable dependency injection and route handling. [[1]](diffhunk://#diff-4a3d6b518f5f8aaee6e65d5a79c081c2e201c11ee1b85ce635c23ae51cec7f41R25-R26) [[2]](diffhunk://#diff-4a3d6b518f5f8aaee6e65d5a79c081c2e201c11ee1b85ce635c23ae51cec7f41R37) [[3]](diffhunk://#diff-4a3d6b518f5f8aaee6e65d5a79c081c2e201c11ee1b85ce635c23ae51cec7f41R50)