### PR TITLE
feat: implement update own password functionality 

### DIFF
--- a/src/domain/identity/core/errors/invalid-password.error.ts
+++ b/src/domain/identity/core/errors/invalid-password.error.ts
@@ -1,0 +1,6 @@
+export class InvalidPasswordError extends Error {
+  constructor() {
+    super('A senha atual fornecida é inválida.');
+    this.name = 'InvalidPasswordError';
+  }
+}

--- a/src/domain/identity/core/errors/same-password.error.ts
+++ b/src/domain/identity/core/errors/same-password.error.ts
@@ -1,0 +1,6 @@
+export class SamePasswordError extends Error {
+  constructor() {
+    super('A nova senha não pode ser igual à senha atual.');
+    this.name = 'SamePasswordError';
+  }
+}

--- a/src/domain/identity/core/use-cases/update-own-password.use-case.ts
+++ b/src/domain/identity/core/use-cases/update-own-password.use-case.ts
@@ -1,0 +1,80 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { compare, hash } from 'bcryptjs';
+import { Either, left, right } from '@/domain/_shared/utils/either';
+import { UsersRepository } from '@/domain/repositories/users.repository';
+import { UserNotFoundError } from '../errors/user-not-found.error';
+import { SamePasswordError } from '../errors/same-password.error';
+import { InvalidPasswordError } from '../errors/invalid-password.error';
+
+export interface UpdateOwnPasswordInput {
+  userId: string;
+  currentPassword: string;
+  newPassword: string;
+}
+
+export interface UpdateOwnPasswordOutput {
+  message: string;
+}
+
+type Output = Either<
+  UserNotFoundError | InvalidPasswordError | SamePasswordError,
+  UpdateOwnPasswordOutput
+>;
+
+@Injectable()
+export class UpdateOwnPasswordUseCase {
+  private readonly logger = new Logger(UpdateOwnPasswordUseCase.name);
+
+  constructor(
+    private readonly usersRepository: UsersRepository,
+  ) {}
+
+  async execute({
+    userId,
+    currentPassword,
+    newPassword,
+  }: UpdateOwnPasswordInput): Promise<Output> {
+    this.logger.log('Starting password update', { userId });
+
+    try {
+      const user = await this.usersRepository.findById(userId);
+      if (!user) {
+        this.logger.warn('User not found', { userId });
+        return left(new UserNotFoundError(userId, 'id'));
+      }
+
+      const isPasswordValid = await compare(
+        currentPassword,
+        user.password,
+      );
+
+      if (!isPasswordValid) {
+        this.logger.warn('Invalid current password', { userId });
+        return left(new InvalidPasswordError());
+      }
+
+      const isSamePassword = await compare(
+        newPassword,
+        user.password,
+      );
+
+      if (isSamePassword) {
+        this.logger.warn('New password is the same as current', { userId });
+        return left(new SamePasswordError());
+      }
+
+      const hashedPassword = await hash(newPassword, 12);
+
+      await this.usersRepository.updatePassword(userId, hashedPassword);
+
+      this.logger.log('Password updated successfully', { userId });
+
+      return right({
+        message: 'Password updated successfully',
+      });
+    } catch (error) {
+      this.logger.error('Error updating password', error.stack);
+      throw error;
+    }
+  }
+}

--- a/src/domain/identity/http/controllers/update-own-password.controller.ts
+++ b/src/domain/identity/http/controllers/update-own-password.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Patch,
+  UseGuards,
+  BadRequestException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { UpdateOwnPasswordUseCase } from '../../core/use-cases/update-own-password.use-case';
+import { UserNotFoundError } from '../../core/errors/user-not-found.error';
+import { InvalidPasswordError } from '../../core/errors/invalid-password.error';
+import { SamePasswordError } from '../../core/errors/same-password.error';
+import { JwtAuthGuard } from '@/domain/_shared/auth/jwt/jwt-auth.guard';
+import { CurrentUser } from '@/domain/_shared/auth/decorators/current-user.decorator';
+import { TokenPayload } from '@/domain/_shared/auth/jwt/jwt.strategy';
+import { UpdateOwnPasswordDto } from '../dtos/update-own-password.use-case';
+
+@Controller('users/me')
+@UseGuards(JwtAuthGuard)
+export class UpdateOwnPasswordController {
+  private readonly logger = new Logger(UpdateOwnPasswordController.name);
+
+  constructor(
+    private readonly updateOwnPasswordUseCase: UpdateOwnPasswordUseCase,
+  ) {}
+
+  @Patch('password')
+  @HttpCode(HttpStatus.OK)
+  async handle(
+    @CurrentUser() user: TokenPayload,
+    @Body() body: UpdateOwnPasswordDto,
+  ) {
+    this.logger.log('PATCH /users/me/password', { userId: user.sub });
+
+    const result = await this.updateOwnPasswordUseCase.execute({
+      userId: user.sub,
+      currentPassword: body.currentPassword,
+      newPassword: body.newPassword,
+    });
+
+    if (result.isLeft()) {
+      const error = result.value;
+
+      if (error instanceof UserNotFoundError) {
+        this.logger.error('User not found', { userId: user.sub });
+        throw new BadRequestException('User not found');
+      }
+
+      if (error instanceof InvalidPasswordError) {
+        this.logger.warn('Invalid current password', { userId: user.sub });
+        throw new UnauthorizedException('Current password is incorrect');
+      }
+
+      if (error instanceof SamePasswordError) {
+        this.logger.warn('Same password provided', { userId: user.sub });
+        throw new BadRequestException(
+          'New password must be different from current password',
+        );
+      }
+
+      throw error;
+    }
+
+    return {
+      message: result.value.message,
+    };
+  }
+}

--- a/src/domain/identity/http/dtos/update-own-password.use-case.ts
+++ b/src/domain/identity/http/dtos/update-own-password.use-case.ts
@@ -1,0 +1,21 @@
+import {
+  IsNotEmpty, IsString, IsStrongPassword,
+} from 'class-validator';
+
+export class UpdateOwnPasswordDto {
+  @IsNotEmpty({ message: 'A senha atual é necessária' })
+  @IsString()
+    currentPassword: string;
+
+  @IsNotEmpty({ message: 'A nova senha é necessária' })
+  @IsStrongPassword({
+    minLength: 8,
+    minLowercase: 1,
+    minUppercase: 1,
+    minNumbers: 1,
+    minSymbols: 1,
+  }, {
+    message: 'Senha deve ter pelo menos 8 caracteres, incluindo: 1 letra minúscula, 1 maiúscula, 1 número e 1 caractere especial',
+  })
+    newPassword: string;
+}

--- a/src/domain/identity/http/http.module.ts
+++ b/src/domain/identity/http/http.module.ts
@@ -34,6 +34,8 @@ import { GetMyProfileController } from './controllers/get-my-profile.controller'
 import { GetMyProfileUseCase } from '../core/use-cases/get-my-profile.use-case';
 import { DeleteAccountController } from './controllers/delete-account.controller';
 import { DeleteAccountUseCase } from '../core/use-cases/delete-account.use-case';
+import { UpdateOwnPasswordController } from './controllers/update-own-password.controller';
+import { UpdateOwnPasswordUseCase } from '../core/use-cases/update-own-password.use-case';
 
 @Module({
   imports: [RepositoriesModule, AttachmentsModule],
@@ -53,6 +55,7 @@ import { DeleteAccountUseCase } from '../core/use-cases/delete-account.use-case'
     ListArtisanFollowersController,
     ToggleArtisanFollowController,
     GetArtisanFollowStatusController,
+    UpdateOwnPasswordController,
     UpdatePersonalProfileDataController,
   ],
   providers: [
@@ -75,6 +78,7 @@ import { DeleteAccountUseCase } from '../core/use-cases/delete-account.use-case'
     ListArtisanFollowingUseCase,
     GetArtisanFollowStatusUseCase,
     UpdateArtisanProfileUseCase,
+    UpdateOwnPasswordUseCase,
     UpdatePersonalProfileDataUseCase,
   ],
 })

--- a/src/domain/repositories/users.repository.ts
+++ b/src/domain/repositories/users.repository.ts
@@ -222,4 +222,14 @@ export class UsersRepository {
       where: { userId },
     });
   }
+
+  async updatePassword(userId: string, hashedPassword: string): Promise<void> {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        password: hashedPassword,
+        updatedAt: new Date(),
+      },
+    });
+  }
 }


### PR DESCRIPTION
This pull request introduces a new feature that allows authenticated users to update their own password securely. It adds all necessary domain logic, error handling, validation, and integrates the new use case into the HTTP module. The main changes are grouped below.

**New Use Case: Update Own Password**

* Added `UpdateOwnPasswordUseCase` which handles the logic for updating a user's password, including validation for current password, prevention of using the same password, and proper error handling. (`src/domain/identity/core/use-cases/update-own-password.use-case.ts`)
* Implemented new error classes: `InvalidPasswordError` and `SamePasswordError` to represent specific failure cases in the password update process. (`src/domain/identity/core/errors/invalid-password.error.ts`, `src/domain/identity/core/errors/same-password.error.ts`) [[1]](diffhunk://#diff-27ee477e000cd89099894120774b1849f6b11008a5f6bef3cb9d9c53ecf1ee1eR1-R6) [[2]](diffhunk://#diff-4bc9fed7b98a077e03830c3f5d8a107da25caccd12fffb75166e7e61ace5d602R1-R6)
* Added a DTO with strong password validation for the password update endpoint. (`src/domain/identity/http/dtos/update-own-password.use-case.ts`)

**HTTP Layer Integration**

* Created `UpdateOwnPasswordController` to expose the password update functionality via a PATCH endpoint at `/users/me/password`, including appropriate error responses and authentication guard. (`src/domain/identity/http/controllers/update-own-password.controller.ts`)
* Registered the new controller and use case in the HTTP module providers and controllers arrays. (`src/domain/identity/http/http.module.ts`) [[1]](diffhunk://#diff-4a3d6b518f5f8aaee6e65d5a79c081c2e201c11ee1b85ce635c23ae51cec7f41R37-R38) [[2]](diffhunk://#diff-4a3d6b518f5f8aaee6e65d5a79c081c2e201c11ee1b85ce635c23ae51cec7f41R58) [[3]](diffhunk://#diff-4a3d6b518f5f8aaee6e65d5a79c081c2e201c11ee1b85ce635c23ae51cec7f41R81)

**Repository Update**

* Added `updatePassword` method to `UsersRepository` to persist the new hashed password and update the `updatedAt` timestamp. (`src/domain/repositories/users.repository.ts`)

closes #143 