### PR TITLE
feat: implement delete product functionality with error handling

### DIFF
--- a/src/domain/products/core/errors/unauthorized-product-access.error.ts
+++ b/src/domain/products/core/errors/unauthorized-product-access.error.ts
@@ -1,0 +1,6 @@
+export class UnauthorizedProductAccessError extends Error {
+  constructor() {
+    super('Você não tem permissão para acessar este produto.');
+    this.name = 'UnauthorizedProductAccessError';
+  }
+}

--- a/src/domain/products/core/use-cases/delete-product.use-case.ts
+++ b/src/domain/products/core/use-cases/delete-product.use-case.ts
@@ -1,0 +1,136 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Either, left, right } from '@/domain/_shared/utils/either';
+import { ProductsRepository } from '@/domain/repositories/products.repository';
+import { AttachmentsRepository } from '@/domain/repositories/attachments.repository';
+import { S3StorageService } from '@/domain/attachments/s3-storage.service';
+import { ProductNotFoundError } from '../errors/product-not-found.error';
+import { UnauthorizedProductAccessError } from '../errors/unauthorized-product-access.error';
+
+export interface DeleteProductInput {
+  productId: string;
+  userId: string;
+}
+
+export interface DeleteProductOutput {
+  message: string;
+  deletedResources: {
+    attachments: number;
+    likes: number;
+    ratings: number;
+  };
+}
+
+type Output = Either<
+  ProductNotFoundError | UnauthorizedProductAccessError,
+  DeleteProductOutput
+>;
+
+@Injectable()
+export class DeleteProductUseCase {
+  private readonly logger = new Logger(DeleteProductUseCase.name);
+
+  constructor(
+    private readonly productsRepository: ProductsRepository,
+    private readonly attachmentsRepository: AttachmentsRepository,
+    private readonly s3StorageService: S3StorageService,
+  ) {}
+
+  async execute({ productId, userId }: DeleteProductInput): Promise<Output> {
+    this.logger.log('Starting product deletion', { productId, userId });
+
+    try {
+      const product = await this.productsRepository.findByIdCore(productId);
+
+      if (!product) {
+        this.logger.warn('Product not found', { productId });
+        return left(new ProductNotFoundError(productId));
+      }
+
+      if (product.artisanId !== userId) {
+        this.logger.warn('Unauthorized product access', { productId, userId, ownerId: product.artisanId });
+        return left(new UnauthorizedProductAccessError());
+      }
+
+      const deletedAttachments = await this.deleteProductAttachments(productId);
+
+      const fullProduct = await this.productsRepository.findById(productId);
+      if (fullProduct?.coverImageId) {
+        await this.deleteFromS3(fullProduct.coverImageId);
+      }
+
+      await this.productsRepository.deleteProductLikes(productId);
+      const likesCount = fullProduct?.likesCount || 0;
+
+      // 6. Deletar ratings e suas imagens
+      const deletedRatings = await this.deleteProductRatings(productId);
+
+      // 7. Deletar o produto
+      await this.productsRepository.delete(productId);
+
+      this.logger.log('Product deleted successfully', {
+        productId,
+        deletedAttachments,
+        deletedRatings,
+      });
+
+      return right({
+        message: 'Product deleted successfully',
+        deletedResources: {
+          attachments: deletedAttachments,
+          likes: likesCount,
+          ratings: deletedRatings,
+        },
+      });
+    } catch (error) {
+      this.logger.error('Error deleting product', error.stack);
+      throw error;
+    }
+  }
+
+  private async deleteProductAttachments(productId: string): Promise<number> {
+    this.logger.log('Deleting product attachments', { productId });
+
+    const attachments = await this.attachmentsRepository.findByEntityId(productId);
+
+    await Promise.all(
+      attachments.map(async (attachment) => {
+        await this.deleteFromS3(attachment.id);
+        await this.attachmentsRepository.delete(attachment.id);
+      }),
+    );
+
+    return attachments.length;
+  }
+
+  private async deleteProductRatings(productId: string): Promise<number> {
+    this.logger.log('Deleting product ratings', { productId });
+
+    const ratings = await this.attachmentsRepository.findRatingsByProductId(productId);
+
+    await Promise.all(
+      ratings.map(async (rating) => {
+        const ratingImages = await this.attachmentsRepository.findByReviewId(rating.id!);
+
+        await Promise.all(
+          ratingImages.map(async (image) => {
+            await this.deleteFromS3(image.id);
+            await this.attachmentsRepository.delete(image.id);
+          }),
+        );
+      }),
+    );
+
+    await this.productsRepository.deleteProductRatings(productId);
+
+    return ratings.length;
+  }
+
+  private async deleteFromS3(key: string): Promise<void> {
+    try {
+      this.logger.log('Deleting from S3', { key });
+      await this.s3StorageService.delete(key);
+    } catch (error) {
+      this.logger.error('Error deleting from S3', { key, error: error.message });
+    }
+  }
+}

--- a/src/domain/products/http/controllers/delete-product.controller.ts
+++ b/src/domain/products/http/controllers/delete-product.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Controller,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Param,
+  UseGuards,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { DeleteProductUseCase } from '../../core/use-cases/delete-product.use-case';
+import { ProductNotFoundError } from '../../core/errors/product-not-found.error';
+import { UnauthorizedProductAccessError } from '../../core/errors/unauthorized-product-access.error';
+import { JwtAuthGuard } from '@/domain/_shared/auth/jwt/jwt-auth.guard';
+import { CurrentUser } from '@/domain/_shared/auth/decorators/current-user.decorator';
+import { TokenPayload } from '@/domain/_shared/auth/jwt/jwt.strategy';
+
+@Controller('products')
+@UseGuards(JwtAuthGuard)
+export class DeleteProductController {
+  private readonly logger = new Logger(DeleteProductController.name);
+
+  constructor(private readonly deleteProductUseCase: DeleteProductUseCase) {}
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  async handle(
+    @CurrentUser() user: TokenPayload,
+    @Param('id') productId: string,
+  ) {
+    this.logger.log('DELETE /products/:id', { productId, userId: user.sub });
+
+    const result = await this.deleteProductUseCase.execute({
+      productId,
+      userId: user.sub,
+    });
+
+    if (result.isLeft()) {
+      const error = result.value;
+
+      if (error instanceof ProductNotFoundError) {
+        this.logger.error('Product not found', { productId });
+        throw new NotFoundException('Product not found');
+      }
+
+      if (error instanceof UnauthorizedProductAccessError) {
+        this.logger.error('Unauthorized product access', { productId, userId: user.sub });
+        throw new ForbiddenException('You are not authorized to delete this product');
+      }
+
+      throw error;
+    }
+
+    return {
+      message: result.value.message,
+      data: result.value.deletedResources,
+    };
+  }
+}

--- a/src/domain/products/http/dtos/create-product.dto.ts
+++ b/src/domain/products/http/dtos/create-product.dto.ts
@@ -2,7 +2,6 @@ import {
   IsArray,
   IsNotEmpty,
   IsNumber,
-  IsOptional,
   IsString,
   IsUUID,
   IsPositive,
@@ -65,7 +64,6 @@ export class CreateProductDto {
   @Type(() => Number)
     stock: number;
 
-  @IsOptional()
   @IsArray({ message: 'Fotos devem ser uma lista' })
   @ArrayMaxSize(20, { message: 'Máximo de 20 fotos permitidas' })
   @IsUUID(4, { each: true, message: 'Cada foto deve ter um ID válido' })

--- a/src/domain/products/http/http-products.module.ts
+++ b/src/domain/products/http/http-products.module.ts
@@ -31,6 +31,8 @@ import { GetFavoritesByUserIdController } from './controllers/get-favorites-by-u
 import { GetFavoritesByUserIdUseCase } from '../core/use-cases/get-favorites-by-user-id.use-case';
 import { GetHomeFeedController } from './controllers/get-home-feed.controller';
 import { GetHomeFeedUseCase } from '../core/use-cases/get-home-feed.use-case';
+import { DeleteProductController } from './controllers/delete-product.controller';
+import { DeleteProductUseCase } from '../core/use-cases/delete-product.use-case';
 
 @Module({
   imports: [RepositoriesModule, AttachmentsModule],
@@ -50,6 +52,7 @@ import { GetHomeFeedUseCase } from '../core/use-cases/get-home-feed.use-case';
     GetProductReviewAverageController,
     DeleteProductReviewController,
     AdminDeleteProductReviewController,
+    DeleteProductController,
   ],
   providers: [
     CreateProductUseCase,
@@ -67,6 +70,7 @@ import { GetHomeFeedUseCase } from '../core/use-cases/get-home-feed.use-case';
     GetProductReviewAverageUseCase,
     DeleteProductReviewUseCase,
     AdminDeleteProductReviewUseCase,
+    DeleteProductUseCase,
   ],
 })
 export class HttpProductsModule {}

--- a/src/domain/repositories/attachments.repository.ts
+++ b/src/domain/repositories/attachments.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Attachment } from '@prisma/client';
+import { Attachment, ProductRating } from '@prisma/client';
 import { PrismaService } from '@/shared/prisma/prisma.service';
 
 export interface CreateAttachmentData {
@@ -140,6 +140,23 @@ export class AttachmentsRepository {
   async findByEntityId(entityId: string): Promise<Attachment[]> {
     return this.prisma.attachment.findMany({
       where: { productId: entityId },
+    });
+  }
+
+  async findByReviewId(reviewId: string): Promise<Attachment[]> {
+    return this.prisma.attachment.findMany({
+      where: { reviewId },
+    });
+  }
+
+  async findRatingsByProductId(productId: string): Promise<Partial<ProductRating>[]> {
+    return this.prisma.productRating.findMany({
+      where: { productId },
+      select: {
+        id: true,
+        comment: true,
+        rating: true,
+      },
     });
   }
 }


### PR DESCRIPTION
This pull request introduces the ability to delete a product, including all associated resources such as attachments, ratings (and their images), and likes. It implements both the use case logic and the HTTP controller, ensures proper error handling for unauthorized access and not found cases, and updates the module and repository to support these operations.

**Product Deletion Feature**

* Added `DeleteProductUseCase` to handle product deletion, including:
  * Authorization check (only the product owner can delete)
  * Deletion of product attachments (including files from S3)
  * Deletion of product ratings and their images
  * Deletion of product likes
  * Error handling for not found and unauthorized access cases [[1]](diffhunk://#diff-ebdff95d80cbd8716191276894efb3340929090112adcf91aee613c6cc60de9fR1-R136) [[2]](diffhunk://#diff-f2c66898dae1039d6b35c43a0ddd7f4590ad5e56b24d4aa618ad2032d3f19d23R1-R6)

* Added `DeleteProductController` to expose the deletion endpoint (`DELETE /products/:id`) with proper authentication and error responses

**Repository Enhancements**

* Extended `AttachmentsRepository` with methods to:
  * Find attachments by review ID
  * Find ratings by product ID [[1]](diffhunk://#diff-7215be80c64cf13f0a191e01fd1c853c6e8f37b0ae8141d153d648a6cdd60f7fL2-R2) [[2]](diffhunk://#diff-7215be80c64cf13f0a191e01fd1c853c6e8f37b0ae8141d153d648a6cdd60f7fR145-R161)

**Module Registration**

* Registered the new controller and use case in `HttpProductsModule` [[1]](diffhunk://#diff-d1fcea023704a918443dfa03f8275136cb0c5a5e7f4ca5eef68e1f611060cdc8R34-R35) [[2]](diffhunk://#diff-d1fcea023704a918443dfa03f8275136cb0c5a5e7f4ca5eef68e1f611060cdc8R55) [[3]](diffhunk://#diff-d1fcea023704a918443dfa03f8275136cb0c5a5e7f4ca5eef68e1f611060cdc8R73)

**Validation Adjustment**

* Removed the `@IsOptional()` decorator from the `photos` field in `CreateProductDto`, making the field required if present [[1]](diffhunk://#diff-10d732b1e17c90a153a09f79731b2b9d796716cdc7d47ce236b39926d63f14fcL5) [[2]](diffhunk://#diff-10d732b1e17c90a153a09f79731b2b9d796716cdc7d47ce236b39926d63f14fcL68)